### PR TITLE
Moved functions that have 2001 data to accepting 2001 as a valid year

### DIFF
--- a/R/kp_misc_stats.R
+++ b/R/kp_misc_stats.R
@@ -530,7 +530,7 @@ kp_game_attrs <- function(
 #'   try(kp_fanmatch(date="2022-02-22"))
 #' }
 
-kp_fanmatch <- function(date = "2022-02-22"){
+kp_fanmatch <- function(date){
   tryCatch(
     expr = {
       if (!has_kp_user_and_pw()) stop("This function requires a KenPom subscription e-mail and password combination, set as the system environment variables KP_USER and KP_PW.", "\n       See ?kp_user_pw for details.", call. = FALSE)

--- a/R/kp_ratings_tables.R
+++ b/R/kp_ratings_tables.R
@@ -49,9 +49,9 @@ kp_pomeroy_ratings <- function(min_year, max_year = most_recent_mbb_season()){
     expr = {
       if (!has_kp_user_and_pw()) stop("This function requires a KenPom subscription e-mail and password combination,\n      set as the system environment variables KP_USER and KP_PW.", "\n       See ?kp_user_pw for details.", call. = FALSE)
       browser <- login()
-      if (!(is.numeric(min_year) && nchar(min_year) == 4 && min_year >= 2002)) {
+      if (!(is.numeric(min_year) && nchar(min_year) == 4 && min_year >= 2001)) {
         # Check if year is numeric, if not NULL
-        cli::cli_abort("Enter valid min_ as a number (YYYY), data only goes back to 2002")
+        cli::cli_abort("Enter valid min_ as a number (YYYY), data only goes back to 2001")
       }
 
       years <- min_year:max_year
@@ -166,9 +166,9 @@ kp_efficiency <- function(min_year, max_year = most_recent_mbb_season()){
     expr = {
       if (!has_kp_user_and_pw()) stop("This function requires a KenPom subscription e-mail and password combination,\n      set as the system environment variables KP_USER and KP_PW.", "\n       See ?kp_user_pw for details.", call. = FALSE)
       browser <- login()
-      if (!(is.numeric(min_year) && nchar(min_year) == 4 && min_year >= 2002)) {
+      if (!(is.numeric(min_year) && nchar(min_year) == 4 && min_year >= 2001)) {
         # Check if year is numeric, if not NULL
-        cli::cli_abort("Enter valid min_year as a number (YYYY), data only goes back to 2002")
+        cli::cli_abort("Enter valid min_ as a number (YYYY), data only goes back to 2001")
       }
 
 
@@ -340,9 +340,9 @@ kp_fourfactors <- function(min_year, max_year = most_recent_mbb_season()){
     expr = {
       if (!has_kp_user_and_pw()) stop("This function requires a KenPom subscription e-mail and password combination,\n      set as the system environment variables KP_USER and KP_PW.", "\n       See ?kp_user_pw for details.", call. = FALSE)
       browser <- login()
-      if (!(is.numeric(min_year) && nchar(min_year) == 4 && min_year >= 2002)) {
+      if (!(is.numeric(min_year) && nchar(min_year) == 4 && min_year >= 2001)) {
         # Check if year is numeric, if not NULL
-        cli::cli_abort("Enter valid min_year as a number (YYYY), data only goes back to 2002")
+        cli::cli_abort("Enter valid min_ as a number (YYYY), data only goes back to 2001")
       }
 
 
@@ -458,9 +458,9 @@ kp_pointdist <- function(min_year, max_year = most_recent_mbb_season()){
     expr = {
       if (!has_kp_user_and_pw()) stop("This function requires a KenPom subscription e-mail and password combination,\n      set as the system environment variables KP_USER and KP_PW.", "\n       See ?kp_user_pw for details.", call. = FALSE)
       browser <- login()
-      if (!(is.numeric(min_year) && nchar(min_year) == 4 && min_year >= 2002)) {
+      if (!(is.numeric(min_year) && nchar(min_year) == 4 && min_year >= 2001)) {
         # Check if year is numeric, if not NULL
-        cli::cli_abort("Enter valid min_year as a number (YYYY), data only goes back to 2002")
+        cli::cli_abort("Enter valid min_ as a number (YYYY), data only goes back to 2001")
       }
 
 
@@ -884,9 +884,9 @@ kp_teamstats <- function(min_year, max_year=most_recent_mbb_season()){
     expr = {
       if (!has_kp_user_and_pw()) stop("This function requires a KenPom subscription e-mail and password combination,\n      set as the system environment variables KP_USER and KP_PW.", "\n       See ?kp_user_pw for details.", call. = FALSE)
       browser <- login()
-      if (!(is.numeric(min_year) && nchar(min_year) == 4 && min_year >= 2002)) {
+      if (!(is.numeric(min_year) && nchar(min_year) == 4 && min_year >= 2001)) {
         # Check if year is numeric, if not NULL
-        cli::cli_abort("Enter valid min_year as a number (YYYY), data only goes back to 2002")
+        cli::cli_abort("Enter valid min_ as a number (YYYY), data only goes back to 2001")
       }
 
 

--- a/R/kp_team_tables.R
+++ b/R/kp_team_tables.R
@@ -53,9 +53,9 @@ kp_team_schedule <- function(team, year = 2022){
     expr = {
       if (!has_kp_user_and_pw()) stop("This function requires a KenPom subscription e-mail and password combination,\n      set as the system environment variables KP_USER and KP_PW.", "\n       See ?kp_user_pw for details.", call. = FALSE)
       browser <- login()
-      if (!(is.numeric(year) && nchar(year) == 4 && year >= 2002)) {
+      if (!(is.numeric(year) && nchar(year) == 4 && year >= 2001)) {
         # Check if year is numeric, if not NULL
-        cli::cli_abort("Enter valid year as a number (YYYY), data only goes back to 2002")
+        cli::cli_abort("Enter valid year as a number (YYYY), data only goes back to 2001")
       }
 
       if (!(team %in% hoopR::teams_links$Team)) {
@@ -517,9 +517,9 @@ kp_gameplan <- function(team, year=2021){
     expr = {
       if (!has_kp_user_and_pw()) stop("This function requires a KenPom subscription e-mail and password combination,\n      set as the system environment variables KP_USER and KP_PW.", "\n       See ?kp_user_pw for details.", call. = FALSE)
       browser <- login()
-      if (!(is.numeric(year) && nchar(year) == 4 && year >= 2002)) {
+      if (!(is.numeric(min_year) && nchar(min_year) == 4 && min_year >= 2001)) {
         # Check if year is numeric, if not NULL
-        cli::cli_abort("Enter valid year as a number (YYYY), data only goes back to 2002")
+        cli::cli_abort("Enter valid min_ as a number (YYYY), data only goes back to 2001")
       }
 
       if (!(team %in% hoopR::teams_links$Team)) {
@@ -786,10 +786,9 @@ kp_opptracker <- function(team, year = 2021){
     expr = {
       if (!has_kp_user_and_pw()) stop("This function requires a KenPom subscription e-mail and password combination,\n      set as the system environment variables KP_USER and KP_PW.", "\n       See ?kp_user_pw for details.", call. = FALSE)
       browser <- login()
-
-      if (!(is.numeric(year) && nchar(year) == 4 && year >= 2002)) {
+      if (!(is.numeric(min_year) && nchar(min_year) == 4 && min_year >= 2001)) {
         # Check if year is numeric, if not NULL
-        cli::cli_abort("Enter valid year as a number (YYYY), data only goes back to 2002")
+        cli::cli_abort("Enter valid min_ as a number (YYYY), data only goes back to 2001")
       }
 
       if (!(team %in% hoopR::teams_links$Team)) {


### PR DESCRIPTION
KenPom recently published 2001 data to select endpoints on his site. On functions servicing that data, I have allowed 2001 to be an accepted year: 

```
if (!(is.numeric(min_year) && nchar(min_year) == 4 && 
            min_year >= **2001**)) {
            cli::cli_abort("Enter valid min_ as a number (YYYY), data only goes back to **2001**")
        }
```