### PR TITLE
Issue 120/game date field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hoopR
 Title: Access Men's Basketball Play by Play Data
-Version: 2.0.0
+Version: 2.0.1
 Authors@R: 
     c(person(given = "Saiem",
              family = "Gilani",

--- a/R/nba_stats_scoreboard.R
+++ b/R/nba_stats_scoreboard.R
@@ -117,7 +117,7 @@ nba_schedule <- function(
             .data$season_type_id == 3 ~ "All-Star",
             .data$season_type_id == 4 ~ "Playoffs",
             .data$season_type_id == 5 ~ "Play-In Game"),
-          game_date = lubridate::ymd(substring(.data$game_date,1,10)))
+          game_date = lubridate::mdy(substring(.data$game_date,1,10)))
 
     },
     error = function(e) {


### PR DESCRIPTION
This fixes #120 by switching from `lubridate::ymd()` to `lubridate::mdy()` to match format of dates returned from NBA API. Tested locally and gives expected results for currently-working and currently-erroring years