### PR TITLE
Add info about player on court in play-by-play data

### DIFF
--- a/man/nba_pbp.Rd
+++ b/man/nba_pbp.Rd
@@ -4,10 +4,12 @@
 \alias{nba_pbp}
 \title{\strong{Get NBA Stats API play-by-play}}
 \usage{
-nba_pbp(game_id, version = "v2", p, ...)
+nba_pbp(game_id, on_court = FALSE, version = "v2", p, ...)
 }
 \arguments{
 \item{game_id}{Game ID}
+
+\item{on_court}{IF TRUE will be added ID of players on court}
 
 \item{version}{Play-by-play version ("v2" available from 2016-17 onwards)}
 
@@ -59,6 +61,16 @@ Returns a data frame: PlayByPlay\tabular{ll}{
    player3_team_abbreviation \tab character \cr
    video_available_flag \tab character \cr
    team_leading \tab character \cr
+   away_player1 \tab numeric \cr
+   away_player2 \tab numeric \cr
+   away_player3 \tab numeric \cr
+   away_player4 \tab numeric \cr
+   away_player5 \tab numeric \cr
+   home_player1 \tab numeric \cr
+   home_player2 \tab numeric \cr
+   home_player3 \tab numeric \cr
+   home_player4 \tab numeric \cr
+   home_player5 \tab numeric \cr
 }
 }
 \description{

--- a/man/nba_pbps.Rd
+++ b/man/nba_pbps.Rd
@@ -4,10 +4,18 @@
 \alias{nba_pbps}
 \title{\strong{Get NBA Stats API play-by-play (Multiple Games)}}
 \usage{
-nba_pbps(game_ids = NULL, version = "v2", nest_data = FALSE, ...)
+nba_pbps(
+  game_ids = NULL,
+  on_court = FALSE,
+  version = "v2",
+  nest_data = FALSE,
+  ...
+)
 }
 \arguments{
 \item{game_ids}{Game IDs}
+
+\item{on_court}{IF TRUE will be added ID of players on court}
 
 \item{version}{Play-by-play version ("v2" available from 2016-17 onwards)}
 
@@ -59,6 +67,16 @@ Returns a data frame: PlayByPlay\tabular{ll}{
    player3_team_abbreviation \tab character \cr
    video_available_flag \tab character \cr
    team_leading \tab character \cr
+   away_player1 \tab numeric \cr
+   away_player2 \tab numeric \cr
+   away_player3 \tab numeric \cr
+   away_player4 \tab numeric \cr
+   away_player5 \tab numeric \cr
+   home_player1 \tab numeric \cr
+   home_player2 \tab numeric \cr
+   home_player3 \tab numeric \cr
+   home_player4 \tab numeric \cr
+   home_player5 \tab numeric \cr
 }
 }
 \description{

--- a/tests/testthat/test-nba_pbp.R
+++ b/tests/testthat/test-nba_pbp.R
@@ -2,7 +2,7 @@ test_that("NBA PBP", {
   skip_on_cran()
   skip_on_ci()
 
-  x <- nba_pbp(game_id = "0022201086")
+  x1 <- nba_pbp(game_id = "0022201086")
 
   cols_x1 <- c(
     "game_id",
@@ -49,8 +49,70 @@ test_that("NBA PBP", {
   )
 
 
-  expect_equal(sort(colnames(x)), sort(cols_x1))
-  expect_s3_class(x, "data.frame")
+  expect_equal(sort(colnames(x1)), sort(cols_x1))
+  expect_s3_class(x1, "data.frame")
+
+  Sys.sleep(3)
+
+  x2 <- nba_pbp(game_id = "0022201086", on_court = TRUE)
+
+  cols_x2 <- c(
+    "game_id",
+    "event_num",
+    "event_type",
+    "event_action_type",
+    "period",
+    "minute_game",
+    "time_remaining",
+    "wc_time_string",
+    "time_quarter",
+    "minute_remaining_quarter",
+    "seconds_remaining_quarter",
+    "home_description",
+    "neutral_description",
+    "visitor_description",
+    "score",
+    "away_score",
+    "home_score",
+    "score_margin",
+    "person1type",
+    "player1_id",
+    "player1_name",
+    "player1_team_id",
+    "player1_team_city",
+    "player1_team_nickname",
+    "player1_team_abbreviation",
+    "person2type",
+    "player2_id",
+    "player2_name",
+    "player2_team_id",
+    "player2_team_city",
+    "player2_team_nickname",
+    "player2_team_abbreviation",
+    "person3type",
+    "player3_id",
+    "player3_name",
+    "player3_team_id",
+    "player3_team_city",
+    "player3_team_nickname",
+    "player3_team_abbreviation",
+    "video_available_flag",
+    "team_leading",
+    "away_player1",
+    "away_player2",
+    "away_player3",
+    "away_player4",
+    "away_player5",
+    "home_player1",
+    "home_player2",
+    "home_player3",
+    "home_player4",
+    "home_player5"
+  )
+
+
+  expect_equal(sort(colnames(x2)), sort(cols_x2))
+  expect_s3_class(x2, "data.frame")
 
   Sys.sleep(3)
 

--- a/tests/testthat/test-nba_pbps.R
+++ b/tests/testthat/test-nba_pbps.R
@@ -2,7 +2,7 @@ test_that("NBA PBPs", {
   skip_on_cran()
   skip_on_ci()
   y <- c("0022201086", "0022200021")
-  x <- nba_pbps(game_ids = y)
+  x1 <- nba_pbps(game_ids = y)
 
   cols_x1 <- c(
     "game_id",
@@ -49,8 +49,70 @@ test_that("NBA PBPs", {
   )
 
 
-  expect_equal(sort(colnames(x)), sort(cols_x1))
-  expect_s3_class(x, "data.frame")
+  expect_equal(sort(colnames(x1)), sort(cols_x1))
+  expect_s3_class(x1, "data.frame")
+
+  Sys.sleep(3)
+
+  x2 <- nba_pbps(game_ids = y, on_court = TRUE)
+
+  cols_x2 <- c(
+    "game_id",
+    "event_num",
+    "event_type",
+    "event_action_type",
+    "period",
+    "minute_game",
+    "time_remaining",
+    "wc_time_string",
+    "time_quarter",
+    "minute_remaining_quarter",
+    "seconds_remaining_quarter",
+    "home_description",
+    "neutral_description",
+    "visitor_description",
+    "score",
+    "away_score",
+    "home_score",
+    "score_margin",
+    "person1type",
+    "player1_id",
+    "player1_name",
+    "player1_team_id",
+    "player1_team_city",
+    "player1_team_nickname",
+    "player1_team_abbreviation",
+    "person2type",
+    "player2_id",
+    "player2_name",
+    "player2_team_id",
+    "player2_team_city",
+    "player2_team_nickname",
+    "player2_team_abbreviation",
+    "person3type",
+    "player3_id",
+    "player3_name",
+    "player3_team_id",
+    "player3_team_city",
+    "player3_team_nickname",
+    "player3_team_abbreviation",
+    "video_available_flag",
+    "team_leading",
+    "away_player1",
+    "away_player2",
+    "away_player3",
+    "away_player4",
+    "away_player5",
+    "home_player1",
+    "home_player2",
+    "home_player3",
+    "home_player4",
+    "home_player5"
+  )
+
+
+  expect_equal(sort(colnames(x2)), sort(cols_x2))
+  expect_s3_class(x2, "data.frame")
 
   Sys.sleep(3)
 


### PR DESCRIPTION
Added a function .players_on_court that allows you to add information about players on the court to the play-by-play data.

The addition is done using the on_court parameter in the functions nba_pbp and nba_pbps